### PR TITLE
Fixed ARC silent Cast error from NSString* to CFStringRef

### DIFF
--- a/DDNSLoggerLogger.m
+++ b/DDNSLoggerLogger.m
@@ -60,7 +60,7 @@ static Logger *_DDNSLogger_logger = nil;
 
 - (void)setupWithBonjourServiceName:(NSString *)serviceName
 {
-    LoggerSetupBonjour(_DDNSLogger_logger, NULL, (CFStringRef)serviceName);
+    LoggerSetupBonjour(_DDNSLogger_logger, NULL, (__bridge CFStringRef)serviceName);
 }
 
 - (void)logMessage:(DDLogMessage *)logMessage


### PR DESCRIPTION
An ARC-related error prevents the bridge from working. This is a quick-and-easy fix to it.
