### PR TITLE
Use singleton pattern recognized by the analyzer.

### DIFF
--- a/DDNSLoggerLogger.m
+++ b/DDNSLoggerLogger.m
@@ -10,32 +10,18 @@
 
 @implementation DDNSLoggerLogger
 
-static DDNSLoggerLogger *sharedInstance;
+static DDNSLoggerLogger *sharedInstance = nil;
 
 // The logger instance we use
 static Logger *_DDNSLogger_logger = nil;
 
-/**
- * The runtime sends initialize to each class in a program exactly one time just before the class,
- * or any class that inherits from it, is sent its first message from within the program. (Thus the
- * method may never be invoked if the class is not used.) The runtime sends the initialize message to
- * classes in a thread-safe manner. Superclasses receive this message before their subclasses.
- *
- * This method may also be called directly (assumably by accident), hence the safety mechanism.
- **/
-+ (void)initialize
-{
-	static BOOL initialized = NO;
-	if (!initialized)
-	{
-		initialized = YES;
-
-		sharedInstance = [[DDNSLoggerLogger alloc] init];
-	}
-}
-
 + (DDNSLoggerLogger *)sharedInstance
 {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[self alloc] init];
+  });
+
 	return sharedInstance;
 }
 


### PR DESCRIPTION
The analyzer was issuing a warning for a leak when using
+initialize to implement the singleton pattern. Use the
more conventional dispatch_once in sharedInstance method.
