### PR TITLE
fix for CocoaLumberjack 2.0, fix when using together with TTY

### DIFF
--- a/DDNSLoggerLogger.h
+++ b/DDNSLoggerLogger.h
@@ -6,6 +6,11 @@
 #import <Foundation/Foundation.h>
 #import "DDLog.h"
 
+extern NSString * const DDNSLoggerOptionBonjourServiceName; // NSString, not defined by default
+
+// If a TTY logger is attached to CocoaLumberjack, set this option to NO to avoid NSLogger to capture messages sent to itself.
+extern NSString * const DDNSLoggerOptionCaptureSystemConsole; // Boolean NSNumber, YES by default
+
 @interface DDNSLoggerLogger : DDAbstractLogger <DDLogger>
 
 @property (nonatomic, readonly) BOOL running;
@@ -13,7 +18,7 @@
 + (DDNSLoggerLogger *)sharedInstance;
 
 /// should setup before `- (void)start`
-- (void)setupWithBonjourServiceName:(NSString *)serviceName;
+- (void)setupWithOptions:(NSDictionary *)options;
 
 - (void)start;
 - (void)stop;

--- a/DDNSLoggerLogger.m
+++ b/DDNSLoggerLogger.m
@@ -52,25 +52,25 @@ static DDNSLoggerLogger *sharedInstance;
 }
 
 - (void)logMessage:(DDLogMessage *)logMessage {
-    NSString *logMsg = logMessage->logMsg;
+    NSString *logMsg = logMessage.message;
 
-    if (formatter) {
+    if (_logFormatter) {
         // formatting is supported but not encouraged!
-        logMsg = [formatter formatLogMessage:logMessage];
+        logMsg = [_logFormatter formatLogMessage:logMessage];
     }
 
     if (logMsg) {
         int nsloggerLogLevel;
-        switch (logMessage->logFlag) {
+        switch (logMessage->_flag) {
                 // NSLogger log levels start a 0, the bigger the number,
                 // the more specific / detailed the trace is meant to be
-            case LOG_FLAG_ERROR: nsloggerLogLevel = 0; break;
-            case LOG_FLAG_WARN: nsloggerLogLevel  = 1; break;
-            case LOG_FLAG_INFO: nsloggerLogLevel  = 2; break;
+            case DDLogFlagError: nsloggerLogLevel = 0; break;
+            case DDLogFlagWarning: nsloggerLogLevel  = 1; break;
+            case DDLogFlagInfo: nsloggerLogLevel  = 2; break;
             default: nsloggerLogLevel             = 3; break;
         }
 
-        LogMessageF(logMessage->file, logMessage->lineNumber, logMessage->function, [logMessage fileName],
+        LogMessageF([logMessage->_file UTF8String], (int)logMessage->_line, [logMessage->_function UTF8String], logMessage->_fileName,
                     nsloggerLogLevel, @"%@", logMsg);
     }
 }

--- a/DDNSLoggerLogger.m
+++ b/DDNSLoggerLogger.m
@@ -8,6 +8,9 @@
 // NSLogger is needed: http://github.com/fpillet/NSLogger
 #import "LoggerClient.h"
 
+NSString * const DDNSLoggerOptionBonjourServiceName = @"bonjourServiceName";
+NSString * const DDNSLoggerOptionCaptureSystemConsole = @"captureSystemConsole";
+
 @interface DDNSLoggerLogger ()
 
 @property (nonatomic, assign) BOOL running;
@@ -42,11 +45,25 @@ static DDNSLoggerLogger *sharedInstance;
     self.running = NO;
 }
 
-- (void)setupWithBonjourServiceName:(NSString *)serviceName {
+- (void)setupWithOptions:(NSDictionary *)options {
     BOOL running = self.running;
     [self stop];
-    LoggerSetupBonjour(NULL, NULL, (__bridge CFStringRef)serviceName);
-    if (running) {
+	
+	NSString *bonjourServiceName = options[DDNSLoggerOptionBonjourServiceName];
+	BOOL captureSystemConsole = YES;
+	if (options[DDNSLoggerOptionCaptureSystemConsole] != nil) {
+		captureSystemConsole = [options[DDNSLoggerOptionCaptureSystemConsole] boolValue];
+	}
+	
+	uint32_t loggerOptions = LOGGER_DEFAULT_OPTIONS;
+	if (!captureSystemConsole) {
+		loggerOptions &= (uint32_t)~kLoggerOption_CaptureSystemConsole;
+	}
+	
+    LoggerSetupBonjour(NULL, NULL, (__bridge CFStringRef)bonjourServiceName);
+	LoggerSetOptions(NULL, loggerOptions);
+	
+	if (running) {
         [self start];
     }
 }


### PR DESCRIPTION
- Fixes to make it work with CocoaLumberjack 2.0.
- By default, NSLogger captures messages sent to the console. I've added an option to disable it to avoid to see NSLogger capturing messages sent to itself if a TTY logger is attached to CocoaLumberjack.