### PR TITLE
Fixed DDNSLoggerLogger for current version of CocoaLumberjack

### DIFF
--- a/DDNSLoggerLogger.m
+++ b/DDNSLoggerLogger.m
@@ -52,26 +52,28 @@ static DDNSLoggerLogger *sharedInstance;
 }
 
 - (void)logMessage:(DDLogMessage *)logMessage {
-    NSString *logMsg = logMessage->logMsg;
-
-    if (formatter) {
+    NSString *logMsg = logMessage.message;
+    
+    if (_logFormatter)
+    {
         // formatting is supported but not encouraged!
-        logMsg = [formatter formatLogMessage:logMessage];
+        logMsg = [_logFormatter formatLogMessage:logMessage];
     }
-
-    if (logMsg) {
+    
+    if (logMsg)
+    {
         int nsloggerLogLevel;
-        switch (logMessage->logFlag) {
+        switch (logMessage.flag)
+        {
                 // NSLogger log levels start a 0, the bigger the number,
                 // the more specific / detailed the trace is meant to be
-            case LOG_FLAG_ERROR: nsloggerLogLevel = 0; break;
-            case LOG_FLAG_WARN: nsloggerLogLevel  = 1; break;
-            case LOG_FLAG_INFO: nsloggerLogLevel  = 2; break;
-            default: nsloggerLogLevel             = 3; break;
+            case LOG_FLAG_ERROR : nsloggerLogLevel = 0; break;
+            case LOG_FLAG_WARN  : nsloggerLogLevel = 1; break;
+            case LOG_FLAG_INFO  : nsloggerLogLevel = 2; break;
+            default : nsloggerLogLevel = 3; break;
         }
-
-        LogMessageF(logMessage->file, logMessage->lineNumber, logMessage->function, [logMessage fileName],
-                    nsloggerLogLevel, @"%@", logMsg);
+        
+        LogMessageF([logMessage.file UTF8String], logMessage.line, [logMessage.function UTF8String], logMessage.fileName, nsloggerLogLevel, @"%@", logMsg);
     }
 }
 


### PR DESCRIPTION
The current version of CocoaLumberjack does not compile with the connector. These changes were published online as a solution (by virt87 https://github.com/steipete/NSLogger-CocoaLumberjack-connector/issues/11). I tested the change and it works.